### PR TITLE
Return 403 when forbidden instead of 500

### DIFF
--- a/armor_config_template.yml
+++ b/armor_config_template.yml
@@ -9,7 +9,7 @@ Note: All waffle related options are only valid if your ES node is running on wi
 #armor.enabled: true
 
 # Path where to write/read the armor master key file
-#armor.key_path: .
+#armor.key_path: /var/lib/elasticseach
 
 # When using DLS or FLS and a get or mget is performed then rewrite it as search request
 armor.rewrite_get_as_search: true

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,11 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh-fg</id>
+            <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh-fg</id>
+            <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>

--- a/src/main/java/com/petalmd/armor/authorization/ForbiddenException.java
+++ b/src/main/java/com/petalmd/armor/authorization/ForbiddenException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 PetalMD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.petalmd.armor.authorization;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.logging.support.LoggerMessageFormat;
+import org.elasticsearch.rest.RestStatus;
+
+public class ForbiddenException extends ElasticsearchException {
+
+    private static final long serialVersionUID = 9118173376408153851L;
+
+    public ForbiddenException(String msg, Object...params) {
+        super(LoggerMessageFormat.format(msg, params));
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.FORBIDDEN;
+    }
+
+
+
+}

--- a/src/test/java/com/petalmd/armor/AbstractScenarioTest.java
+++ b/src/test/java/com/petalmd/armor/AbstractScenarioTest.java
@@ -210,10 +210,10 @@ public abstract class AbstractScenarioTest extends AbstractUnitTest {
             assertJestResultCount(result, 7);
 
             result = executeGet(indices[0], "test", "dummy", false, false).v1();
-            assertJestResultError(result, "Unallowed action RestGetAction");
+            assertJestResultError(result, "ForbiddenException[Forbidden action RestGetAction . Allowed actions: [RestSearchAction]]");
 
             result = executeIndexAsString("{}", indices[0], "test", null, false, false).v1();
-            assertJestResultError(result, "Unallowed action RestIndexAction");
+            assertJestResultError(result, "ForbiddenException[Forbidden action RestIndexAction . Allowed actions: [RestSearchAction]]");
         } else {
 
             JestResult result = executeSearch("ac_query_matchall.json", indices, null, false, false).v1();

--- a/src/test/java/com/petalmd/armor/TestScenarios.java
+++ b/src/test/java/com/petalmd/armor/TestScenarios.java
@@ -130,12 +130,13 @@ public class TestScenarios extends AbstractScenarioTest {
                 .put("armor.authentication.authorizer.cache.enable", "true")
                 .put("armor.authentication.authentication_backend.impl",
                         "com.petalmd.armor.authentication.backend.ldap.LDAPAuthenticationBackend")
-                        .put("armor.authentication.authentication_backend.cache.enable", "true")
-                        .putArray("armor.authentication.ldap.host", "localhost:" + ldapServerPort)
-                        .put("armor.authentication.ldap.usersearch", "(uid={0})")
+                .put("armor.authentication.authentication_backend.cache.enable", "true")
+                .putArray("armor.authentication.ldap.host", "localhost:" + ldapServerPort)
+                .put("armor.authentication.ldap.usersearch", "(uid={0})")
                 .put("armor.authentication.ldap.username_attribute", "uid")
-                        .put("armor.authentication.authorization.ldap.rolesearch", "(uniqueMember={0})")
-                        .put("armor.authentication.authorization.ldap.rolename", "cn").build();
+                .put("armor.authentication.authorization.ldap.rolesearch", "(uniqueMember={0})")
+                .put("armor.authentication.authorization.ldap.rolename", "cn")
+                .build();
 
         dlsLdapUserAttribute(settings);
     }

--- a/src/test/java/com/petalmd/armor/TransportTest.java
+++ b/src/test/java/com/petalmd/armor/TransportTest.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.petalmd.armor.authorization.ForbiddenException;
 import com.petalmd.armor.service.ArmorService;
 import com.petalmd.armor.util.ConfigConstants;
 import com.petalmd.armor.util.SecurityUtil;
@@ -195,8 +196,8 @@ public class TransportTest extends AbstractUnitTest {
                     (GetRequest) new GetRequest(indices[0], "test", "dummy").putHeader("armor_transport_creds",
                             "amFja3Nvbm06c2VjcmV0")).actionGet();
             Assert.fail();
-        } catch (final RuntimeException e) {
-            Assert.assertTrue(e.getCause().getMessage(), e.getCause().getMessage().contains("is forbidden"));
+        } catch (final ForbiddenException e) {
+            //exp Forbidden exception
         }
 
         try {
@@ -204,8 +205,8 @@ public class TransportTest extends AbstractUnitTest {
                     (IndexRequest) new IndexRequest(indices[0], "test").source("{}").putHeader("armor_transport_creds",
                             "amFja3Nvbm06c2VjcmV0")).actionGet();
             Assert.fail();
-        } catch (final RuntimeException e) {
-            Assert.assertTrue(e.getCause().getMessage(), e.getCause().getMessage().contains("is forbidden"));
+        } catch (final ForbiddenException e) {
+            //exp Forbidden exception
         }
 
         try {

--- a/src/test/java/com/petalmd/armor/WindowsTest.java
+++ b/src/test/java/com/petalmd/armor/WindowsTest.java
@@ -32,19 +32,16 @@ public class WindowsTest extends AbstractScenarioTest {
 
         final Settings settings = ImmutableSettings
                 .settingsBuilder()
+                .put("armor.authentication.http_authenticator", "com.petalmd.armor.authentication.http.waffle.HTTPWaffleAuthenticator")
 
-                .put("armor.authentication.http_authenticator",
-                        "com.petalmd.armor.authentication.http.waffle.HTTPWaffleAuthenticator")
-                        .put("armor.authentication.spnego.login_config_filepath", System.getProperty("java.security.auth.login.config"))
-
-                .put("armor.authentication.authorizer.cache.enable", "false")
-                        .put("armor.authentication.authentication_backend",
-                                "com.petalmd.armor.authentication.backend.simple.AlwaysSucceedAuthenticationBackend")
-                                .put("armor.authentication.authentication_backend.cache.enable", "false")
-                                .put("armor.waffle.windows_auth_provider_impl", MockWindowsAuthProvider.class)
-
+                .put("armor.authentication.spnego.login_config_filepath", System.getProperty("java.security.auth.login.config"))
+                .put("armor.authentication.authentication_backend", "com.petalmd.armor.authentication.backend.simple.AlwaysSucceedAuthenticationBackend")
+                .put("armor.authentication.authentication_backend.cache.enable", "false")
+                .put("armor.waffle.windows_auth_provider_impl", MockWindowsAuthProvider.class)
                 .put("armor.authentication.authorizer", "com.petalmd.armor.authorization.waffle.WaffleAuthorizator")
-                .put("armor.authentication.authentication_backend.cache.enable", "false").build();
+                .put("armor.authentication.authorizer.cache.enable", "false")
+
+                .build();
 
         username = "Guest";
         password = "Guest";


### PR DESCRIPTION
Fix for : HTTP response may be 401/403 when authentication/authorization fails
(https://github.com/floragunncom/search-guard/issues/25) 
