### PR TITLE
Adding an option to not allow all cluster:monitor actions

### DIFF
--- a/src/main/java/com/petalmd/armor/filter/AbstractActionFilter.java
+++ b/src/main/java/com/petalmd/armor/filter/AbstractActionFilter.java
@@ -83,7 +83,7 @@ public abstract class AbstractActionFilter implements ActionFilter {
         log.debug("Context {}", request.getContext());
         log.debug("Headers {}", request.getHeaders());
 
-        if (action.startsWith("cluster:monitor/")) {
+        if (settings.getAsBoolean(ConfigConstants.ARMOR_ALLOW_CLUSTER_MONITOR, true) && action.startsWith("cluster:monitor/")) {
             chain.proceed(action, request, listener);
             return;
         }

--- a/src/main/java/com/petalmd/armor/filter/ArmorActionFilter.java
+++ b/src/main/java/com/petalmd/armor/filter/ArmorActionFilter.java
@@ -128,7 +128,7 @@ public class ArmorActionFilter implements ActionFilter {
     private void apply0(final String action, final ActionRequest request, final ActionListener listener, final ActionFilterChain chain)
             throws Exception {
 
-        if (action.startsWith("cluster:monitor/")) {
+        if (settings.getAsBoolean(ConfigConstants.ARMOR_ALLOW_CLUSTER_MONITOR, true) && action.startsWith("cluster:monitor/")) {
             chain.proceed(action, request, listener);
             return;
         }

--- a/src/main/java/com/petalmd/armor/util/ConfigConstants.java
+++ b/src/main/java/com/petalmd/armor/util/ConfigConstants.java
@@ -23,6 +23,7 @@ public final class ConfigConstants {
     public static final String ARMOR_ACTIONREQUESTFILTER = "armor.actionrequestfilter.names";
     public static final String ARMOR_ALLOW_ALL_FROM_LOOPBACK = "armor.allow_all_from_loopback";
     public static final String ARMOR_ALLOW_NON_LOOPBACK_QUERY_ON_ARMOR_INDEX = "armor.allow_non_loopback_query_on_armor_index";
+    public static final String ARMOR_ALLOW_CLUSTER_MONITOR = "armor.allow_cluster_monitor";
     public static final String ARMOR_AUDITLOG_ENABLED = "armor.auditlog.enabled";
     public static final String ARMOR_TRANSPORT_AUTH_ENABLED = "armor.transport_auth.enabled";
     public static final String ARMOR_AUTHENTICATION_AUTHENTICATION_BACKEND = "armor.authentication.authentication_backend.impl";


### PR DESCRIPTION
Hello, First of all thanks for porting guard to ES 1.7 by creating armor. I'm now trying to extend the armor functionalities. This pull request has for goal to not allow all cluster:monitor actions if they are not forbidden explicitly. For example we want to allow only cluster:monitor/health and cluster:monitor/nodes to allow kibana to work but we don't want to give the users the ability to see others informations given by the _cat endpoint. 
Basically i added an option to disable the special treatment of cluster:monitor actions. the default value of the option will imply the same behavior as before. I also added a small test. If you have time could you review my code ?
